### PR TITLE
FIx AddonPathIssue  issue #13

### DIFF
--- a/models/header/general_operators.py
+++ b/models/header/general_operators.py
@@ -93,7 +93,7 @@ class VNT_OT_save_preferences(Operator):
     bl_idname = "vnt.save_preferences"
     bl_description = "Open user general settings window"
     
-    pref_loc : StringProperty(default=bpy.utils.script_paths(subdir='addons')[1]+"/venturial/preferences/user_custom_settings.json")
+    pref_loc : StringProperty(default=bpy.utils.script_paths(subdir='addons')[-1]+"/venturial/preferences/user_custom_settings.json")
     
     def __init__(self, cs=None, pref_data=None):
         """Initialise a dictionary to store the user preferences for dumping 
@@ -143,7 +143,7 @@ class VNT_OT_reset_preferences(Operator):
     bl_idname = "vnt.reset_preferences"
     bl_description = "Reset preferences to system default"
     
-    default_pref_loc : StringProperty(default=bpy.utils.script_paths(subdir='addons')[1]+"/venturial/preferences/system_default_settings.json")
+    default_pref_loc : StringProperty(default=bpy.utils.script_paths(subdir='addons')[-1]+"/venturial/preferences/system_default_settings.json")
     
     def __init__(self, cs=None, default_prefs=None):
         """Initialise a dictionary to store default preferences data read from default_pref_loc"""

--- a/utils/custom_icon_object_generator.py
+++ b/utils/custom_icon_object_generator.py
@@ -4,7 +4,7 @@ custom_icons = {}
 
 def register_custom_icon(icon, rel_path):
     img = bpy.utils.previews.new()
-    img_path = bpy.utils.script_paths(subdir='addons')[1]+rel_path
+    img_path = bpy.utils.script_paths(subdir='addons')[-1]+rel_path
     img.load(icon, img_path, 'IMAGE')
     custom_icons[icon] = img
     

--- a/utils/default_properties.py
+++ b/utils/default_properties.py
@@ -11,11 +11,11 @@ class default_properties:
                                    'default_user_data_path_checkbox',
                                    'default_user_data_path']
         self.default_prefs_values = [False, 
-                                     bpy.utils.script_paths(subdir='addons')[1]+"/venturial/user_data/",
+                                     bpy.utils.script_paths(subdir='addons')[-1]+"/venturial/user_data/",
                                      False,
-                                     bpy.utils.script_paths(subdir='addons')[1]+"/venturial/tutorials/",
+                                     bpy.utils.script_paths(subdir='addons')[-1]+"/venturial/tutorials/",
                                      False,
-                                     bpy.utils.script_paths(subdir='addons')[1]+"/venturial/user_data/"]
+                                     bpy.utils.script_paths(subdir='addons')[-1]+"/venturial/user_data/"]
         self.default_prefs_dict = {}
         
         


### PR DESCRIPTION
So it tries to get list =bpy.utils.script_paths(subdir='addons')[1] 

in latest we have only one element inside list which is user one 
               >>> bpy.utils.script_paths(subdir='addons')
               ['C:\\Users\\user\\AppData\\Roaming\\Blender Foundation\\Blender\\4.3\\scripts\\addons']


in blender 3.2.1
              >>> bpy.utils.script_paths(subdir="addons")
             ['C:\\Program Files\\Blender Foundation\\Blender 3.2\\3.2\\scripts\\addons', 
             'C:\\Users\\user\\AppData\\Roaming\\Blender Foundation\\Blender\\3.2\\scripts\\addons']
so i change the index to -1 so it takes only one which is user User dict